### PR TITLE
Fixing failing test for src/fib.ts

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,10 +1,10 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n: number): number {
   if (n < 0) {
     return -1;
-  } else if (n == 0) {
+  } else if (n === 0) {
     return 0;
-  } else if (n == 1) {
+  } else if (n === 1) {
     return 1;
   }
 


### PR DESCRIPTION
Fixed tests #11 which were failing because of "Operands of '+' operation with any is possible only with string, number, bigint or any"